### PR TITLE
Adding the possibility to exclude default values when serializing

### DIFF
--- a/src/Utf8Json/Resolvers/DynamicObjectResolver.cs
+++ b/src/Utf8Json/Resolvers/DynamicObjectResolver.cs
@@ -25,6 +25,8 @@ namespace Utf8Json.Resolvers
         public static readonly IJsonFormatterResolver SnakeCase = DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase.Instance;
         /// <summary>AllowPrivate:False, ExcludeNull:True,  NameMutate:Original</summary>
         public static readonly IJsonFormatterResolver ExcludeNull = DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal.Instance;
+        /// <summary>AllowPrivate:False, ExcludeNull:True, ExcludeDefault:True,  NameMutate:Original</summary>
+        public static readonly IJsonFormatterResolver ExcludeNullExcludeDefault = DynamicObjectResolverAllowPrivateFalseExcludeNullTrueExcludeDefaultTrueNameMutateOriginal.Instance;
         /// <summary>AllowPrivate:False, ExcludeNull:True,  NameMutate:CamelCase</summary>
         public static readonly IJsonFormatterResolver ExcludeNullCamelCase = DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase.Instance;
         /// <summary>AllowPrivate:False, ExcludeNull:True,  NameMutate:SnakeCase</summary>
@@ -38,6 +40,8 @@ namespace Utf8Json.Resolvers
         public static readonly IJsonFormatterResolver AllowPrivateSnakeCase = DynamicObjectResolverAllowPrivateTrueExcludeNullFalseNameMutateSnakeCase.Instance;
         /// <summary>AllowPrivate:True,  ExcludeNull:True,  NameMutate:Original</summary>
         public static readonly IJsonFormatterResolver AllowPrivateExcludeNull = DynamicObjectResolverAllowPrivateTrueExcludeNullTrueNameMutateOriginal.Instance;
+        /// <summary>AllowPrivate:True,  ExcludeNull:True, ExcludeDefault:True,  NameMutate:Original</summary>
+        public static readonly IJsonFormatterResolver AllowPrivateExcludeNullExcludeDefault = DynamicObjectResolverAllowPrivateTrueExcludeNullTrueExcludeDefaultTrueNameMutateOriginal.Instance;
         /// <summary>AllowPrivate:True,  ExcludeNull:True,  NameMutate:CamelCase</summary>
         public static readonly IJsonFormatterResolver AllowPrivateExcludeNullCamelCase = DynamicObjectResolverAllowPrivateTrueExcludeNullTrueNameMutateCamelCase.Instance;
         /// <summary>AllowPrivate:True,  ExcludeNull:True,  NameMutate:SnakeCase</summary>
@@ -65,6 +69,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal();
         static readonly Func<string, string> nameMutator = StringMutator.Original;
         static readonly bool excludeNull = false;
+        static readonly bool excludeDefaultValue = false;
         const string ModuleName = "Utf8Json.Resolvers.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal";
 
         static readonly DynamicAssembly assembly;
@@ -96,7 +101,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull, excludeDefaultValue);
             }
         }
     }
@@ -110,6 +115,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToCamelCase;
         static readonly bool excludeNull = false;
+        static readonly bool excludeDefaultValue = false;
         const string ModuleName = "Utf8Json.Resolvers.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase";
 
         static readonly DynamicAssembly assembly;
@@ -141,7 +147,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull, excludeDefaultValue);
             }
         }
     }
@@ -155,6 +161,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToSnakeCase;
         static readonly bool excludeNull = false;
+        static readonly bool excludeDefaultValue = false;
         const string ModuleName = "Utf8Json.Resolvers.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase";
 
         static readonly DynamicAssembly assembly;
@@ -186,7 +193,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull, excludeDefaultValue);
             }
         }
     }
@@ -200,6 +207,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal();
         static readonly Func<string, string> nameMutator = StringMutator.Original;
         static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = false;
         const string ModuleName = "Utf8Json.Resolvers.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal";
 
         static readonly DynamicAssembly assembly;
@@ -231,7 +239,53 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull, excludeDefaultValue);
+            }
+        }
+    }
+
+    internal sealed class DynamicObjectResolverAllowPrivateFalseExcludeNullTrueExcludeDefaultTrueNameMutateOriginal : IJsonFormatterResolver
+#if DEBUG && (NET45 || NET47)
+            , ISave
+#endif
+    {
+        // configuration
+        public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullTrueExcludeDefaultTrueNameMutateOriginal();
+        static readonly Func<string, string> nameMutator = StringMutator.Original;
+        static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = true;
+        const string ModuleName = "Utf8Json.Resolvers.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueExcludeDefaultTrueNameMutateOriginal";
+
+        static readonly DynamicAssembly assembly;
+
+        static DynamicObjectResolverAllowPrivateFalseExcludeNullTrueExcludeDefaultTrueNameMutateOriginal()
+        {
+            assembly = new DynamicAssembly(ModuleName);
+        }
+
+        DynamicObjectResolverAllowPrivateFalseExcludeNullTrueExcludeDefaultTrueNameMutateOriginal()
+        {
+        }
+
+#if DEBUG && (NET45 || NET47)
+        public AssemblyBuilder Save()
+        {
+            return assembly.Save();
+        }
+#endif
+
+        public IJsonFormatter<T> GetFormatter<T>()
+        {
+            return FormatterCache<T>.formatter;
+        }
+
+        static class FormatterCache<T>
+        {
+            public static readonly IJsonFormatter<T> formatter;
+
+            static FormatterCache()
+            {
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull, excludeDefaultValue);
             }
         }
     }
@@ -245,6 +299,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToCamelCase;
         static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = false;
         const string ModuleName = "Utf8Json.Resolvers.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase";
 
         static readonly DynamicAssembly assembly;
@@ -276,7 +331,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull, excludeDefaultValue);
             }
         }
     }
@@ -290,6 +345,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToSnakeCase;
         static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = false;
         const string ModuleName = "Utf8Json.Resolvers.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase";
 
         static readonly DynamicAssembly assembly;
@@ -321,7 +377,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToAssembly<T>(assembly, Instance, nameMutator, excludeNull, excludeDefaultValue);
             }
         }
     }
@@ -336,6 +392,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateTrueExcludeNullFalseNameMutateOriginal();
         static readonly Func<string, string> nameMutator = StringMutator.Original;
         static readonly bool excludeNull = false;
+        static readonly bool excludeDefaultValue = false;
 
         public IJsonFormatter<T> GetFormatter<T>()
         {
@@ -348,7 +405,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, true);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, excludeDefaultValue, true);
             }
         }
     }
@@ -359,6 +416,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateTrueExcludeNullFalseNameMutateCamelCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToCamelCase;
         static readonly bool excludeNull = false;
+        static readonly bool excludeDefaultValue = false;
 
         public IJsonFormatter<T> GetFormatter<T>()
         {
@@ -371,7 +429,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, true);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, excludeDefaultValue, true);
             }
         }
     }
@@ -382,6 +440,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateTrueExcludeNullFalseNameMutateSnakeCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToSnakeCase;
         static readonly bool excludeNull = false;
+        static readonly bool excludeDefaultValue = false;
 
         public IJsonFormatter<T> GetFormatter<T>()
         {
@@ -394,7 +453,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, true);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, excludeDefaultValue, true);
             }
         }
     }
@@ -405,6 +464,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateTrueExcludeNullTrueNameMutateOriginal();
         static readonly Func<string, string> nameMutator = StringMutator.Original;
         static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = false;
 
         public IJsonFormatter<T> GetFormatter<T>()
         {
@@ -417,7 +477,31 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, true);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, excludeDefaultValue, true);
+            }
+        }
+    }
+
+    internal sealed class DynamicObjectResolverAllowPrivateTrueExcludeNullTrueExcludeDefaultTrueNameMutateOriginal : IJsonFormatterResolver
+    {
+        // configuration
+        public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateTrueExcludeNullTrueExcludeDefaultTrueNameMutateOriginal();
+        static readonly Func<string, string> nameMutator = StringMutator.Original;
+        static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = true;
+
+        public IJsonFormatter<T> GetFormatter<T>()
+        {
+            return FormatterCache<T>.formatter;
+        }
+
+        static class FormatterCache<T>
+        {
+            public static readonly IJsonFormatter<T> formatter;
+
+            static FormatterCache()
+            {
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, excludeDefaultValue, true);
             }
         }
     }
@@ -428,6 +512,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateTrueExcludeNullTrueNameMutateCamelCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToCamelCase;
         static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = false;
 
         public IJsonFormatter<T> GetFormatter<T>()
         {
@@ -440,7 +525,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, true);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, excludeDefaultValue, true);
             }
         }
     }
@@ -451,6 +536,7 @@ namespace Utf8Json.Resolvers.Internal
         public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateTrueExcludeNullTrueNameMutateSnakeCase();
         static readonly Func<string, string> nameMutator = StringMutator.ToSnakeCase;
         static readonly bool excludeNull = true;
+        static readonly bool excludeDefaultValue = false;
 
         public IJsonFormatter<T> GetFormatter<T>()
         {
@@ -463,7 +549,7 @@ namespace Utf8Json.Resolvers.Internal
 
             static FormatterCache()
             {
-                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, true);
+                formatter = (IJsonFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod<T>(Instance, nameMutator, excludeNull, excludeDefaultValue, true);
             }
         }
     }
@@ -520,7 +606,7 @@ namespace Utf8Json.Resolvers.Internal
             {typeof(string)},
         };
 
-        public static object BuildFormatterToAssembly<T>(DynamicAssembly assembly, IJsonFormatterResolver selfResolver, Func<string, string> nameMutator, bool excludeNull)
+        public static object BuildFormatterToAssembly<T>(DynamicAssembly assembly, IJsonFormatterResolver selfResolver, Func<string, string> nameMutator, bool excludeNull, bool excludeDefaultValue)
         {
             var ti = typeof(T).GetTypeInfo();
 
@@ -539,20 +625,20 @@ namespace Utf8Json.Resolvers.Internal
             Type elementType;
             if (typeof(Exception).GetTypeInfo().IsAssignableFrom(ti))
             {
-                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, false, true);
+                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, excludeDefaultValue, false, true);
             }
             else if (ti.IsAnonymous() || TryGetInterfaceEnumerableElementType(typeof(T), out elementType))
             {
-                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, false, false);
+                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, excludeDefaultValue, false, false);
             }
 
-            var formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(assembly, typeof(T), nameMutator, excludeNull);
+            var formatterTypeInfo = DynamicObjectTypeBuilder.BuildType(assembly, typeof(T), nameMutator, excludeNull, excludeDefaultValue);
             if (formatterTypeInfo == null) return null;
 
             return (IJsonFormatter<T>)Activator.CreateInstance(formatterTypeInfo.AsType());
         }
 
-        public static object BuildFormatterToDynamicMethod<T>(IJsonFormatterResolver selfResolver, Func<string, string> nameMutator, bool excludeNull, bool allowPrivate)
+        public static object BuildFormatterToDynamicMethod<T>(IJsonFormatterResolver selfResolver, Func<string, string> nameMutator, bool excludeNull, bool excludeDefaultValue, bool allowPrivate)
         {
             var ti = typeof(T).GetTypeInfo();
 
@@ -569,15 +655,15 @@ namespace Utf8Json.Resolvers.Internal
             }
             if (typeof(Exception).GetTypeInfo().IsAssignableFrom(ti))
             {
-                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, false, true);
+                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, excludeDefaultValue, false, true);
             }
             else
             {
-                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, allowPrivate, false);
+                return DynamicObjectTypeBuilder.BuildAnonymousFormatter(typeof(T), nameMutator, excludeNull, excludeDefaultValue, allowPrivate, false);
             }
         }
 
-        static TypeInfo BuildType(DynamicAssembly assembly, Type type, Func<string, string> nameMutator, bool excludeNull)
+        static TypeInfo BuildType(DynamicAssembly assembly, Type type, Func<string, string> nameMutator, bool excludeNull, bool excludeDefaultValue)
         {
             if (ignoreTypes.Contains(type)) return null;
 
@@ -617,7 +703,7 @@ namespace Utf8Json.Resolvers.Internal
                     il.EmitLoadThis();
                     il.EmitLdfld(fi);
                     return true;
-                }, excludeNull, hasShouldSerialize, 1); // firstArgIndex:0 is this.
+                }, excludeNull, hasShouldSerialize, excludeDefaultValue, 1); // firstArgIndex:0 is this.
             }
 
             {
@@ -640,7 +726,7 @@ namespace Utf8Json.Resolvers.Internal
             return typeBuilder.CreateTypeInfo();
         }
 
-        public static object BuildAnonymousFormatter(Type type, Func<string, string> nameMutator, bool excludeNull, bool allowPrivate, bool isException)
+        public static object BuildAnonymousFormatter(Type type, Func<string, string> nameMutator, bool excludeNull, bool excludeDefaultValue, bool allowPrivate, bool isException)
         {
             if (ignoreTypes.Contains(type)) return false;
 
@@ -673,7 +759,7 @@ namespace Utf8Json.Resolvers.Internal
             var i = 0;
             foreach (var item in serializationInfo.Members.Where(x => x.IsReadable))
             {
-                if (excludeNull || hasShouldSerialize)
+                if (excludeNull || hasShouldSerialize || excludeDefaultValue)
                 {
                     stringByteKeysField.Add(JsonWriter.GetEncodedPropertyName(item.Name));
                 }
@@ -724,19 +810,19 @@ namespace Utf8Json.Resolvers.Internal
             {
                 var il = serialize.GetILGenerator();
                 BuildSerialize(type, serializationInfo, il, () =>
-                 {
-                     il.EmitLdarg(0);
-                 }, (index, member) =>
-                 {
-                     if (serializeCustomFormatters.Count == 0) return false;
-                     if (serializeCustomFormatters[index] == null) return false;
+                {
+                    il.EmitLdarg(0);
+                }, (index, member) =>
+                {
+                    if (serializeCustomFormatters.Count == 0) return false;
+                    if (serializeCustomFormatters[index] == null) return false;
 
-                     il.EmitLdarg(1); // read object[]
-                     il.EmitLdc_I4(index);
-                     il.Emit(OpCodes.Ldelem_Ref); // object
-                     il.Emit(OpCodes.Castclass, serializeCustomFormatters[index].GetType());
-                     return true;
-                 }, excludeNull, hasShouldSerialize, 2);
+                    il.EmitLdarg(1); // read object[]
+                    il.EmitLdc_I4(index);
+                    il.Emit(OpCodes.Ldelem_Ref); // object
+                    il.Emit(OpCodes.Castclass, serializeCustomFormatters[index].GetType());
+                    return true;
+                }, excludeNull, hasShouldSerialize, excludeDefaultValue, 2);
             }
 
             var deserialize = new DynamicMethod("Deserialize", type, new Type[] { typeof(object[]), typeof(JsonReader).MakeByRefType(), typeof(IJsonFormatterResolver) }, type.Module, true);
@@ -857,7 +943,7 @@ namespace Utf8Json.Resolvers.Internal
             return dict;
         }
 
-        static void BuildSerialize(Type type, MetaType info, ILGenerator il, Action emitStringByteKeys, Func<int, MetaMember, bool> tryEmitLoadCustomFormatter, bool excludeNull, bool hasShouldSerialize, int firstArgIndex)
+        static void BuildSerialize(Type type, MetaType info, ILGenerator il, Action emitStringByteKeys, Func<int, MetaMember, bool> tryEmitLoadCustomFormatter, bool excludeNull, bool hasShouldSerialize, bool excludeDefaultValue, int firstArgIndex)
         {
             var argWriter = new ArgumentField(il, firstArgIndex);
             var argValue = new ArgumentField(il, firstArgIndex + 1, type);
@@ -956,7 +1042,7 @@ namespace Utf8Json.Resolvers.Internal
             var index = 0;
             foreach (var item in info.Members.Where(x => x.IsReadable))
             {
-                if (excludeNull || hasShouldSerialize)
+                if (excludeNull || hasShouldSerialize || excludeDefaultValue)
                 {
                     il.MarkLabel(labels[index]);
 
@@ -979,6 +1065,45 @@ namespace Utf8Json.Resolvers.Internal
                             argValue.EmitLoad();
                             item.EmitLoadValue(il);
                             il.Emit(OpCodes.Brfalse_S, (index < labels.Length - 1) ? labels[index + 1] : endObjectLabel); // null, next label
+                        }
+                    }
+                    if (excludeDefaultValue)
+                    {
+                        // if (value == default) continue;
+                        if (item.Type.IsPrimitive)
+                        {
+                            if (item.Type == typeof(double))
+                            {
+                                argValue.EmitLoad();
+                                item.EmitLoadValue(il);
+                                il.Emit(OpCodes.Ldc_R4, 0);
+                                il.Emit(OpCodes.Ceq);
+                                il.Emit(OpCodes.Brtrue_S, (index < labels.Length - 1) ? labels[index + 1] : endObjectLabel); // default value, next label
+                            }
+                            else
+                            {
+                                argValue.EmitLoad();
+                                item.EmitLoadValue(il);
+                                il.Emit(OpCodes.Ldc_I4_0);
+                                il.Emit(OpCodes.Ceq);
+                                il.Emit(OpCodes.Brtrue_S, (index < labels.Length - 1) ? labels[index + 1] : endObjectLabel); // default value, next label
+                            }
+                        }
+                        else if (item.Type == typeof(decimal))
+                        {
+                            argValue.EmitLoad();
+                            item.EmitLoadValue(il);
+                            il.Emit(OpCodes.Ldsfld, EmitInfo.DecimalZeroFld);
+                            il.EmitCall(EmitInfo.DecimalEquals);
+                            il.Emit(OpCodes.Brtrue_S, (index < labels.Length - 1) ? labels[index + 1] : endObjectLabel); // default value, next label
+                        }
+                        else if (item.Type.IsEnum)
+                        {
+                            argValue.EmitLoad();
+                            item.EmitLoadValue(il);
+                            il.Emit(OpCodes.Ldc_I4_0);
+                            il.Emit(OpCodes.Ceq);
+                            il.Emit(OpCodes.Brtrue_S, (index < labels.Length - 1) ? labels[index + 1] : endObjectLabel); // default value, next label
                         }
                     }
                     if (hasShouldSerialize && item.ShouldSerializeMethodInfo != null)
@@ -1502,6 +1627,10 @@ namespace Utf8Json.Resolvers.Internal
             public static readonly MethodInfo TypeEquals = ExpressionUtility.GetMethodInfo((Type t) => t.Equals(default(Type)));
 
             public static readonly MethodInfo NongenericSerialize = ExpressionUtility.GetMethodInfo<Utf8Json.JsonWriter>(writer => JsonSerializer.NonGeneric.Serialize(default(Type), ref writer, default(object), default(IJsonFormatterResolver)));
+
+            public static readonly FieldInfo DecimalZeroFld = typeof(decimal).GetField("Zero");
+            public static readonly MethodInfo DecimalEquals = typeof(decimal).GetMethod("Equals", new Type[] { typeof(decimal), typeof(decimal) });
+
 
             public static MethodInfo Serialize(Type type)
             {

--- a/src/Utf8Json/Resolvers/StandardResolver.cs
+++ b/src/Utf8Json/Resolvers/StandardResolver.cs
@@ -14,6 +14,8 @@ namespace Utf8Json.Resolvers
         public static readonly IJsonFormatterResolver SnakeCase = SnakeCaseStandardResolver.Instance;
         /// <summary>AllowPrivate:False, ExcludeNull:True,  NameMutate:Original</summary>
         public static readonly IJsonFormatterResolver ExcludeNull = ExcludeNullStandardResolver.Instance;
+        /// <summary>AllowPrivate:False, ExcludeNull:True,  NameMutate:Original</summary>
+        public static readonly IJsonFormatterResolver ExcludeNullExcludeDefault = ExcludeNullExcludeDefaultStandardResolver.Instance;
         /// <summary>AllowPrivate:False, ExcludeNull:True,  NameMutate:CamelCase</summary>
         public static readonly IJsonFormatterResolver ExcludeNullCamelCase = ExcludeNullCamelCaseStandardResolver.Instance;
         /// <summary>AllowPrivate:False, ExcludeNull:True,  NameMutate:SnakeCase</summary>
@@ -27,6 +29,8 @@ namespace Utf8Json.Resolvers
         public static readonly IJsonFormatterResolver AllowPrivateSnakeCase = AllowPrivateSnakeCaseStandardResolver.Instance;
         /// <summary>AllowPrivate:True,  ExcludeNull:True,  NameMutate:Original</summary>
         public static readonly IJsonFormatterResolver AllowPrivateExcludeNull = AllowPrivateExcludeNullStandardResolver.Instance;
+        /// <summary>AllowPrivate:True,  ExcludeNull:True, ExcludeDefault:True, NameMutate:Original</summary>
+        public static readonly IJsonFormatterResolver AllowPrivateExcludeNullExcludeDefault = AllowPrivateExcludeNullExcludeDefaultStandardResolver.Instance;
         /// <summary>AllowPrivate:True,  ExcludeNull:True,  NameMutate:CamelCase</summary>
         public static readonly IJsonFormatterResolver AllowPrivateExcludeNullCamelCase = AllowPrivateExcludeNullCamelCaseStandardResolver.Instance;
         /// <summary>AllowPrivate:True,  ExcludeNull:True,  NameMutate:SnakeCase</summary>
@@ -292,6 +296,74 @@ namespace Utf8Json.Resolvers.Internal
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
             static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.ExcludeNull }).ToArray();
+
+            InnerResolver()
+            {
+            }
+
+            public IJsonFormatter<T> GetFormatter<T>()
+            {
+                return FormatterCache<T>.formatter;
+            }
+
+            static class FormatterCache<T>
+            {
+                public static readonly IJsonFormatter<T> formatter;
+
+                static FormatterCache()
+                {
+                    foreach (var item in resolvers)
+                    {
+                        var f = item.GetFormatter<T>();
+                        if (f != null)
+                        {
+                            formatter = f;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    internal sealed class ExcludeNullExcludeDefaultStandardResolver : IJsonFormatterResolver
+    {
+        // configure
+        public static readonly IJsonFormatterResolver Instance = new ExcludeNullExcludeDefaultStandardResolver();
+
+        static readonly IJsonFormatter<object> fallbackFormatter = new DynamicObjectTypeFallbackFormatter(InnerResolver.Instance);
+
+        ExcludeNullExcludeDefaultStandardResolver()
+        {
+        }
+
+        public IJsonFormatter<T> GetFormatter<T>()
+        {
+            return FormatterCache<T>.formatter;
+        }
+
+        static class FormatterCache<T>
+        {
+            public static readonly IJsonFormatter<T> formatter;
+
+            static FormatterCache()
+            {
+                if (typeof(T) == typeof(object))
+                {
+                    formatter = (IJsonFormatter<T>)fallbackFormatter;
+                }
+                else
+                {
+                    formatter = InnerResolver.Instance.GetFormatter<T>();
+                }
+            }
+        }
+
+        sealed class InnerResolver : IJsonFormatterResolver
+        {
+            public static readonly IJsonFormatterResolver Instance = new InnerResolver();
+
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.ExcludeNullExcludeDefault }).ToArray();
 
             InnerResolver()
             {
@@ -705,6 +777,75 @@ namespace Utf8Json.Resolvers.Internal
             public static readonly IJsonFormatterResolver Instance = new InnerResolver();
 
             static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivateExcludeNull }).ToArray();
+
+            InnerResolver()
+            {
+            }
+
+            public IJsonFormatter<T> GetFormatter<T>()
+            {
+                return FormatterCache<T>.formatter;
+            }
+
+            static class FormatterCache<T>
+            {
+                public static readonly IJsonFormatter<T> formatter;
+
+                static FormatterCache()
+                {
+                    foreach (var item in resolvers)
+                    {
+                        var f = item.GetFormatter<T>();
+                        if (f != null)
+                        {
+                            formatter = f;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    internal sealed class AllowPrivateExcludeNullExcludeDefaultStandardResolver : IJsonFormatterResolver
+    {
+        // configure
+        public static readonly IJsonFormatterResolver Instance = new AllowPrivateExcludeNullExcludeDefaultStandardResolver();
+
+
+        static readonly IJsonFormatter<object> fallbackFormatter = new DynamicObjectTypeFallbackFormatter(InnerResolver.Instance);
+
+        AllowPrivateExcludeNullExcludeDefaultStandardResolver()
+        {
+        }
+
+        public IJsonFormatter<T> GetFormatter<T>()
+        {
+            return FormatterCache<T>.formatter;
+        }
+
+        static class FormatterCache<T>
+        {
+            public static readonly IJsonFormatter<T> formatter;
+
+            static FormatterCache()
+            {
+                if (typeof(T) == typeof(object))
+                {
+                    formatter = (IJsonFormatter<T>)fallbackFormatter;
+                }
+                else
+                {
+                    formatter = InnerResolver.Instance.GetFormatter<T>();
+                }
+            }
+        }
+
+        sealed class InnerResolver : IJsonFormatterResolver
+        {
+            public static readonly IJsonFormatterResolver Instance = new InnerResolver();
+
+            static readonly IJsonFormatterResolver[] resolvers = StandardResolverHelper.CompositeResolverBase.Concat(new[] { DynamicObjectResolver.AllowPrivateExcludeNullExcludeDefault }).ToArray();
 
             InnerResolver()
             {


### PR DESCRIPTION
Add 2 Resolver to allow to exclude default value for some types (bool, int, short, long, double, decimal, enum)